### PR TITLE
feat: Take into account device of input tensor

### DIFF
--- a/mlcolvar/core/transform/utils.py
+++ b/mlcolvar/core/transform/utils.py
@@ -78,7 +78,7 @@ class Statistics(object):
         # Initialize
         if self.mean is None:
             for prop in ["mean", "M2", "std"]:
-                setattr(self, prop, torch.zeros(nfeatures))
+                setattr(self, prop, torch.zeros(nfeatures, device=x.device))
 
         # compute sample mean
         sample_mean = torch.mean(x, dim=0)


### PR DESCRIPTION
When initializing the Statistics class the input tensor X might be located in a different device other than cpu. I think torch.zeros() by default initializes in cpu. Thus operations like delta = sample_mean - self.mean (line 88) would contain Tensors in different devices!