### PR TITLE
fix: make sure the average fes has the min at 0

### DIFF
--- a/mlcolvar/utils/fes.py
+++ b/mlcolvar/utils/fes.py
@@ -263,10 +263,6 @@ def compute_fes(
                 [num_samples for i in range(dim)]
             )
 
-        if fes_to_zero is not None:
-            fes_i -= fes_i[fes_to_zero]
-        else:
-            fes_i -= np.nanmin(fes_i)
         # result for each block
         fes_blocks.append(fes_i)
         W_blocks.append(np.sum(w_i))
@@ -290,6 +286,11 @@ def compute_fes(
     else:
         fes = fes_blocks[0]
         error = None
+    
+    if fes_to_zero is not None:
+        fes -= fes[fes_to_zero]
+    else:
+        fes -= np.nanmin(fes)
 
     # rescale back
     if scale_by is not None:


### PR DESCRIPTION
Setting the min of the fes of each block (fes_i) to 0 doesn't guarantee that the min of the average (fes) is at 0. So in order to have the min of the fes at 0 we can apply the offset after averaging.

In addition, I'm not sure it's right to apply a different offset to each fes_i (i.e. np.nanmin(fes_i)) because this will surely affect the final average.